### PR TITLE
ST-289: API to delete lead with the linked doctypes

### DIFF
--- a/crm/api/lead.py
+++ b/crm/api/lead.py
@@ -3,8 +3,6 @@ import frappe
 
 @frappe.whitelist()
 def delete_lead_and_links(name):
-	frappe.delete_doc('CRM Lead', name)
-
 	linked_doctypes = {
 		'Communication': 'reference_name',
 		'Comment': 'reference_name',
@@ -18,4 +16,4 @@ def delete_lead_and_links(name):
 		for doc in linked_docs:
 			frappe.delete_doc(doctype, doc.name)
 
-	frappe.db.commit()
+	frappe.delete_doc('CRM Lead', name)

--- a/crm/api/lead.py
+++ b/crm/api/lead.py
@@ -1,0 +1,21 @@
+import frappe
+
+
+@frappe.whitelist()
+def delete_lead_and_links(name):
+	frappe.delete_doc('CRM Lead', name)
+
+	linked_doctypes = {
+		'Communication': 'reference_name',
+		'Comment': 'reference_name',
+		'CRM Call Log': 'reference_docname',
+		'CRM Task': 'reference_docname',
+		'FCRM Note': 'reference_docname',
+		'File': 'attached_to_name'
+	}
+	for doctype, fieldname in linked_doctypes.items():
+		linked_docs = frappe.get_all(doctype, filters={fieldname: name})
+		for doc in linked_docs:
+			frappe.delete_doc(doctype, doc.name)
+
+	frappe.db.commit()


### PR DESCRIPTION
- [x] PR: https://github.com/hackajob/crm/pull/3
- [x] PR: https://github.com/hackajob/hackajob-bigdave/pull/986
- [x] PR: https://github.com/hackajob/hackajob-api/pull/3178
- [x] PR: https://github.com/hackajob/candidate-microservice/pull/554
- [x] PR: https://github.com/hackajob/hackajob-workspace/pull/2535
- [x] Deploy on the production container
- [x] Fields changes
```
* New fields types
    * ... Social Panel
    * Job Board Key Skills - Text
    * Job Board Personal Summary - Text
    * Job Board Work Eligibility - Text
    * Job Board Desired Locations - Text
    * Job Board Preferred Sectors - Text
    * Job Board Current Job Title - Small Text
    * Job Board CV Link - Small Text
    * Job Board Desired Job Title - Small Text
    * Job Board Full Address - Small Text
    * Job Board Application Activity - Small Text
    * Job Board Current Employer - Small Text
    * Job Board Current Location - Small Text
    * Job Board Desired Contract Type - Small Text
    * Job Board Job Type - Small Text
    * Job Board Languages - Small Text
    * Job Board Last Active - Small Text
    * Job Board Transport - Small Text
* Lead Acquisition Source: graduate-jobs, careerbuilder, cv-library
* Email not mandatory but unique
* Add "hackajob Bot" user
* Add "hackajob Bot" as owner on every field
```