### PR TITLE
CustomCommunication class and streamline SMS logs handling by relying on server-side defaults for columns and rows

### DIFF
--- a/crm/api/lead.py
+++ b/crm/api/lead.py
@@ -20,3 +20,12 @@ def delete_lead_and_links(name):
 
 	frappe.delete_doc('CRM Lead', name)
 	frappe.db.commit()
+
+@frappe.whitelist()
+def can_delete_lead(name: str) -> bool:
+	"""Return True if current user has Delete permission on the given Lead."""
+	try:
+		doc = frappe.get_doc('CRM Lead', name)
+	except frappe.DoesNotExistError:
+		return False
+	return bool(frappe.has_permission('CRM Lead', doc=doc, ptype='delete'))

--- a/crm/hooks.py
+++ b/crm/hooks.py
@@ -132,6 +132,7 @@ before_uninstall = "crm.uninstall.before_uninstall"
 override_doctype_class = {
 	"Contact": "crm.overrides.contact.CustomContact",
 	"Email Template": "crm.overrides.email_template.CustomEmailTemplate",
+	"Communication": "crm.overrides.communication.CustomCommunication",
 }
 
 # Document Events

--- a/crm/overrides/communication.py
+++ b/crm/overrides/communication.py
@@ -1,0 +1,31 @@
+from frappe.core.doctype.communication.communication import Communication
+
+
+class CustomCommunication(Communication):
+	@staticmethod
+	def default_list_data():
+		columns = [
+			{"label": "Sender", "type": "Data", "key": "sender", "width": "12rem"},
+			{"label": "Receiver", "type": "Data", "key": "receiver", "width": "12rem"},
+			{"label": "From", "type": "Data", "key": "phone_no", "width": "12rem"},
+			{"label": "To", "type": "Data", "key": "recipients", "width": "12rem"},
+			{"label": "Message", "type": "Text", "key": "content", "width": "1fr"},
+			{"label": "Direction", "type": "Data", "key": "sent_or_received", "width": "8rem"},
+			{"label": "When", "type": "Datetime", "key": "creation", "width": "10rem"},
+		]
+
+		rows = [
+			"name",
+			"creation",
+			"sent_or_received",
+			"sender",
+			"receiver",
+			"phone_no",
+			"recipients",
+			"content",
+			"reference_doctype",
+			"reference_name",
+			"_liked_by",
+		]
+
+		return {"columns": columns, "rows": rows}

--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -1303,7 +1303,7 @@ const callActions = computed(() => {
   )
 })
 
-defineExpose({ emailBox, all_activities, changeTabTo })
+defineExpose({ emailBox, all_activities, changeTabTo, smsBox })
 </script>
 
 <style scoped>

--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -750,6 +750,7 @@
       v-model="doc"
       v-model:reload="reload_email"
       :doctype="doctype"
+      :hideHeader="title === 'Activity' && smsOpen"
       @scroll="scroll"
     />
     <WhatsAppBox
@@ -763,10 +764,12 @@
     />
     <SmsBox
       ref="smsBox"
-      v-if="title == 'SMS'"
+      v-if="['SMS', 'Activity'].includes(title)"
       v-model="doc"
       :doctype="doctype"
-  @sent="() => { all_activities.reload(); scroll() }"
+      @open="smsOpen = true"
+      @close="smsOpen = false"
+      @sent="() => { smsOpen = false; all_activities.reload(); scroll() }"
     />
   </div>
   <WhatsappTemplateSelectorModal
@@ -1254,6 +1257,7 @@ function timelineIcon(activity_type, is_lead) {
 const emailBox = ref(null)
 const whatsappBox = ref(null)
 const smsBox = ref(null)
+const smsOpen = ref(false)
 
 watch([reload, reload_email], ([reload_value, reload_email_value]) => {
   if (reload_value || reload_email_value) {

--- a/frontend/src/components/Activities/ActivityHeader.vue
+++ b/frontend/src/components/Activities/ActivityHeader.vue
@@ -1,64 +1,25 @@
 <template>
-  <div
-    v-if="title !== 'Data'"
-    class="mx-4 my-3 flex items-center justify-between text-lg font-medium sm:mx-10 sm:mb-4 sm:mt-8"
-  >
+  <div v-if="title !== 'Data'"
+    class="mx-4 my-3 flex items-center justify-between text-lg font-medium sm:mx-10 sm:mb-4 sm:mt-8">
     <div class="flex h-8 items-center text-xl font-semibold text-ink-gray-8">
       {{ __(title) }}
     </div>
-    <Button
-      v-if="title == 'Emails'"
-      variant="solid"
-      :label="__('New Email')"
-      iconLeft="plus"
-      @click="emailBox.show = true"
-    />
-    <Button
-      v-else-if="title == 'Comments'"
-      variant="solid"
-      :label="__('New Comment')"
-      iconLeft="plus"
-      @click="emailBox.showComment = true"
-    />
-    <MultiActionButton
-      v-else-if="title == 'Calls'"
-      variant="solid"
-      :options="callActions"
-    />
-    <Button
-      v-else-if="title == 'Notes'"
-      variant="solid"
-      :label="__('New Note')"
-      iconLeft="plus"
-      @click="modalRef.showNote()"
-    />
-    <Button
-      v-else-if="title == 'Tasks'"
-      variant="solid"
-      :label="__('New Task')"
-      iconLeft="plus"
-      @click="modalRef.showTask()"
-    />
-    <Button
-      v-else-if="title == 'Attachments'"
-      variant="solid"
-      :label="__('Upload Attachment')"
-      iconLeft="plus"
-      @click="showFilesUploader = true"
-    />
+    <Button v-if="title == 'Emails'" variant="solid" :label="__('New Email')" iconLeft="plus"
+      @click="emailBox.show = true" />
+    <Button v-else-if="title == 'Comments'" variant="solid" :label="__('New Comment')" iconLeft="plus"
+      @click="emailBox.showComment = true" />
+    <MultiActionButton v-else-if="title == 'Calls'" variant="solid" :options="callActions" />
+    <Button v-else-if="title == 'Notes'" variant="solid" :label="__('New Note')" iconLeft="plus"
+      @click="modalRef.showNote()" />
+    <Button v-else-if="title == 'Tasks'" variant="solid" :label="__('New Task')" iconLeft="plus"
+      @click="modalRef.showTask()" />
+    <Button v-else-if="title == 'Attachments'" variant="solid" :label="__('Upload Attachment')" iconLeft="plus"
+      @click="showFilesUploader = true" />
     <div class="flex gap-2 shrink-0" v-else-if="title == 'WhatsApp'">
-      <Button
-        :label="__('Send Template')"
-        @click="showWhatsappTemplates = true"
-      />
-      <Button
-        variant="solid"
-        :label="__('New Message')"
-        iconLeft="plus"
-        @click="whatsappBox.show()"
-      />
+      <Button :label="__('Send Template')" @click="showWhatsappTemplates = true" />
+      <Button variant="solid" :label="__('New Message')" iconLeft="plus" @click="whatsappBox.show()" />
     </div>
-    <Button v-else-if="title == 'SMS'" variant="solid" @click="smsBox.show()">
+    <Button v-else-if="title == 'SMS'" variant="solid" @click="openSms()">
       <template #prefix>
         <FeatherIcon name="plus" class="h-4 w-4" />
       </template>
@@ -66,13 +27,8 @@
     </Button>
     <Dropdown v-else :options="defaultActions" @click.stop>
       <template v-slot="{ open }">
-        <Button
-          variant="solid"
-          class="flex items-center gap-1"
-          :label="__('New')"
-          iconLeft="plus"
-          :iconRight="open ? 'chevron-up' : 'chevron-down'"
-        />
+        <Button variant="solid" class="flex items-center gap-1" :label="__('New')" iconLeft="plus"
+          :iconRight="open ? 'chevron-up' : 'chevron-down'" />
       </template>
     </Dropdown>
   </div>
@@ -89,7 +45,7 @@ import WhatsAppIcon from '@/components/Icons/WhatsAppIcon.vue'
 import SmsIcon from '@/components/Icons/SmsIcon.vue'
 import { globalStore } from '@/stores/global'
 import { whatsappEnabled, callEnabled } from '@/composables/settings'
-import { Dropdown } from 'frappe-ui'
+import { Dropdown, toast } from 'frappe-ui'
 import { computed, h } from 'vue'
 
 const props = defineProps({
@@ -118,10 +74,8 @@ const defaultActions = computed(() => {
     {
       icon: h(SmsIcon, { class: 'h-4 w-4' }),
       label: __('New SMS'),
-      onClick: () => {
-        tabIndex.value = getTabIndex('SMS')
-        setTimeout(() => props.smsBox?.show?.(), 0)
-      },
+      onClick: () => openSms(true),
+      condition: () => !!props.doc?.mobile_no,
     },
     {
       icon: h(CommentIcon, { class: 'h-4 w-4' }),
@@ -168,6 +122,23 @@ const defaultActions = computed(() => {
 
 function getTabIndex(name) {
   return props.tabs.findIndex((tab) => tab.name === name)
+}
+
+function openSms(fromDropdown = false) {
+  if (!props.doc?.mobile_no) return toast.error(__('No phone number set'))
+  // If already on Activity, open SMS box in-place; otherwise, switch to SMS tab
+  if (props.title === 'Activity' && !fromDropdown) {
+    return setTimeout(() => props.smsBox?.show?.(), 0)
+  }
+  if (props.title === 'Activity' && fromDropdown) {
+    // From the New dropdown on Activity, still show in-place
+    return setTimeout(() => props.smsBox?.show?.(), 0)
+  }
+  // If current header is SMS tab, simply show
+  if (props.title === 'SMS') return setTimeout(() => props.smsBox?.show?.(), 0)
+  // Otherwise, navigate to SMS tab and open
+  tabIndex.value = getTabIndex('SMS')
+  setTimeout(() => props.smsBox?.show?.(), 0)
 }
 
 const callActions = computed(() => {

--- a/frontend/src/components/Activities/ActivityHeader.vue
+++ b/frontend/src/components/Activities/ActivityHeader.vue
@@ -84,11 +84,6 @@ const defaultActions = computed(() => {
     },
     {
       icon: h(PhoneIcon, { class: 'h-4 w-4' }),
-      label: __('Log a Call'),
-      onClick: () => props.modalRef.createCallLog(),
-    },
-    {
-      icon: h(PhoneIcon, { class: 'h-4 w-4' }),
       label: __('Make a Call'),
       onClick: () => makeCall(props.doc.mobile_no),
       condition: () => callEnabled.value,
@@ -143,11 +138,6 @@ function openSms(fromDropdown = false) {
 
 const callActions = computed(() => {
   let actions = [
-    {
-      label: __('Log a Call'),
-      icon: 'plus',
-      onClick: () => props.modalRef.createCallLog(),
-    },
     {
       label: __('Make a Call'),
       icon: h(PhoneIcon, { class: 'h-4 w-4' }),

--- a/frontend/src/components/Activities/SmsBox.vue
+++ b/frontend/src/components/Activities/SmsBox.vue
@@ -1,17 +1,11 @@
 <template>
-  <div class="flex items-end gap-2 px-3 py-2.5 sm:px-10">
-    <Textarea
-      ref="textareaRef"
-      type="textarea"
-      class="min-h-8 w-full"
-      :rows="rows"
-      v-model="content"
-      :maxlength="maxLen"
-      :placeholder="placeholder"
-      @focus="rows = 6"
-      @blur="rows = 1"
-      @keydown.enter.stop="(e) => send(e)"
-    />
+  <div v-show="open" class="flex items-end gap-2 px-3 py-2.5 sm:px-10">
+    <Textarea ref="textareaRef" type="textarea" class="min-h-8 w-full" :rows="rows" v-model="content"
+      :maxlength="maxLen" :placeholder="placeholder" @focus="rows = 6" @blur="rows = 1"
+      @keydown.enter.stop="(e) => send(e)" />
+    <Button variant="ghost" @mousedown.prevent.stop="discard">
+      {{ __('Discard') }}
+    </Button>
     <Button variant="solid" :disabled="!content.trim()" @click="send()">
       {{ __('Send') }}
     </Button>
@@ -27,15 +21,32 @@ const props = defineProps({
 })
 
 const doc = defineModel()
+const emit = defineEmits(['sent', 'open', 'close'])
 
 const rows = ref(1)
+const open = ref(false)
 const content = ref('')
 const maxLen = 1000
 const placeholder = ref(__('Type SMS here...'))
 const textareaRef = ref(null)
 
 function show() {
+  open.value = true
+  emit('open')
   nextTick(() => textareaRef.value.el.focus())
+}
+
+function hide() {
+  emit('close')
+  open.value = false
+}
+
+function discard() {
+  hide()
+  nextTick(() => {
+    content.value = ''
+    rows.value = 1
+  })
 }
 
 function send(event) {
@@ -59,7 +70,5 @@ function send(event) {
   })
 }
 
-const emit = defineEmits(['sent'])
-
-defineExpose({ show })
+defineExpose({ show, hide })
 </script>

--- a/frontend/src/components/CommunicationArea.vue
+++ b/frontend/src/components/CommunicationArea.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex justify-between gap-3 border-t px-4 py-2.5 sm:px-10">
+  <div class="flex justify-between gap-3 border-t px-4 py-2.5 sm:px-10" v-show="!hideHeader">
     <div class="flex gap-1.5">
       <Button
         ref="sendEmailRef"
@@ -103,6 +103,7 @@ const props = defineProps({
     type: String,
     default: 'CRM Lead',
   },
+  hideHeader: { type: Boolean, default: false },
 })
 
 const doc = defineModel()

--- a/frontend/src/components/Controls/MultiSelectSelect.vue
+++ b/frontend/src/components/Controls/MultiSelectSelect.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="whitespace-nowrap overflow-hidden">
+    <Autocomplete
+      class="w-full whitespace-nowrap overflow-hidden text-ellipsis"
+      :options="computedOptions"
+      :placeholder="placeholder"
+      :multiple="true"
+      v-model="selectedOptions"
+      @update:modelValue="handleSelectionChange"
+    />
+    <ErrorMessage class="mt-2 pl-2" v-if="error" :message="error" />
+  </div>
+</template>
+
+<script setup>
+import { Autocomplete, ErrorMessage } from 'frappe-ui'
+import { ref, computed, watch } from 'vue'
+
+const props = defineProps({
+  // Array of strings or array of { label, value }
+  options: {
+    type: Array,
+    default: () => [],
+  },
+  placeholder: {
+    type: String,
+    default: 'Select values...',
+  },
+  modelValue: {
+    type: [String, Array],
+    default: () => [],
+  },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const error = ref(null)
+const selectedOptions = ref([])
+
+const computedOptions = computed(() => {
+  // Normalize options to { label, value }
+  return (props.options || []).map((opt) => {
+    if (typeof opt === 'string') {
+      return { label: opt, value: opt }
+    }
+    if (opt && typeof opt === 'object') {
+      return { label: opt.label ?? opt.value, value: opt.value ?? opt.label }
+    }
+    return { label: String(opt), value: String(opt) }
+  })
+})
+
+function handleSelectionChange(newSelection) {
+  // De-duplicate by value
+  const unique = newSelection.filter(
+    (item, idx, self) => self.findIndex((t) => t.value === item.value) === idx,
+  )
+
+  selectedOptions.value = unique
+
+  const arrayValue = unique.length ? unique.map((o) => o.value) : []
+  emit('update:modelValue', arrayValue)
+}
+
+// Sync external modelValue into internal selectedOptions
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    let values = []
+    if (Array.isArray(newValue)) {
+      values = newValue.filter(Boolean)
+    } else if (typeof newValue === 'string' && newValue) {
+      values = newValue
+        .split(',')
+        .map((v) => v.trim())
+        .filter(Boolean)
+    }
+
+    const asOptions = values.map((v) => ({ label: v, value: v }))
+    const current = selectedOptions.value.map((o) => o.value)
+    const nv = new Set(values)
+    const cv = new Set(current)
+    if (
+      nv.size !== cv.size ||
+      [...nv].some((v) => !cv.has(v))
+    ) {
+      selectedOptions.value = asOptions
+    }
+    if (values.length === 0) {
+      selectedOptions.value = []
+    }
+  },
+  { immediate: true },
+)
+</script>

--- a/frontend/src/components/Filter.vue
+++ b/frontend/src/components/Filter.vue
@@ -158,6 +158,7 @@
 import FilterIcon from '@/components/Icons/FilterIcon.vue'
 import Link from '@/components/Controls/Link.vue'
 import MultiSelectLink from '@/components/Controls/MultiSelectLink.vue'
+import MultiSelectSelect from '@/components/Controls/MultiSelectSelect.vue'
 import Autocomplete from '@/components/frappe-ui/Autocomplete.vue'
 import {
   FormControl,
@@ -369,8 +370,8 @@ function getValueControl(f) {
   const { field, operator } = f
   const { fieldtype, options } = field
   if (operator == 'is') {
-  const isChildLink = f.fieldname && f.fieldname.includes('.')
-  if (isChildLink && typeLink.includes(fieldtype) && options) {
+    const isChildLink = f.fieldname && f.fieldname.includes('.')
+    if (isChildLink && typeLink.includes(fieldtype) && options) {
       return h(MultiSelectLink, {
         doctype: options,
         placeholder: `Select ${field.label}...`,
@@ -412,6 +413,19 @@ function getValueControl(f) {
           apply()
         },
         modelValue: f.value
+      })
+    }
+    // For Select fields with 'in'/'not in', use MultiSelectSelect
+    if (typeSelect.includes(fieldtype)) {
+      const _options = getSelectOptions(options).map((o) => ({ label: o, value: o }))
+      return h(MultiSelectSelect, {
+        options: _options,
+        placeholder: `Select ${field.label}...`,
+        'onUpdate:modelValue': (val) => {
+          f.value = val
+          apply()
+        },
+        modelValue: f.value,
       })
     }
     return h(FormControl, { type: 'text' })
@@ -545,12 +559,18 @@ function updateOperator(event, filter) {
     filter.value = getDefaultValue(filter.field)
   }
   if (newOperatorValue === 'is') {
-  const { fieldtype, options, fieldname } = filter.field || {}
-  const isChildLink = fieldname && fieldname.includes('.')
-  if (isChildLink && typeLink.includes(fieldtype) && options) {
+    const { fieldtype, options, fieldname } = filter.field || {}
+    const isChildLink = fieldname && fieldname.includes('.')
+    if (isChildLink && typeLink.includes(fieldtype) && options) {
       filter.value = Array.isArray(filter.value) ? filter.value : []
     } else {
       filter.value = 'set'
+    }
+  } else if (['in', 'not in'].includes(newOperatorValue)) {
+    // Initialize arrays for Link and Select multiselects
+    const { fieldtype } = filter.field || {}
+    if (typeLink.includes(fieldtype) || typeSelect.includes(fieldtype)) {
+      filter.value = Array.isArray(filter.value) ? filter.value : []
     }
   } else if (newOperatorValue === 'is not') {
     filter.value = 'set'

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -482,10 +482,26 @@ function deleteLead() {
 
 function openEmailBox() {
   let currentTab = tabs.value[tabIndex.value]
-  if (!['Emails', 'Comments', 'Activities'].includes(currentTab.name)) {
+  if (!['Emails', 'Comments', 'Activity'].includes(currentTab.name)) {
     activities.value.changeTabTo('emails')
   }
-  nextTick(() => (activities.value.emailBox.show = true))
+  nextTick(() => {
+    activities.value?.smsBox?.hide?.()
+    activities.value.emailBox.show = true
+  })
+}
+
+function openSmsBox() {
+  let currentTab = tabs.value[tabIndex.value]
+  if (!['SMS', 'Activity'].includes(currentTab.name)) {
+    activities.value.changeTabTo('sms')
+  }
+  nextTick(() => {
+    if (activities.value?.emailBox?.show) activities.value.emailBox.show = false
+    if (activities.value?.emailBox?.showComment)
+      activities.value.emailBox.showComment = false
+    activities.value?.smsBox?.show?.()
+  })
 }
 
 function openSmsBox() {

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -159,6 +159,7 @@
                 />
 
                 <Button
+                  v-if="canDeleteLead.data"
                   :tooltip="__('Delete')"
                   variant="subtle"
                   theme="red"
@@ -304,6 +305,14 @@ const { triggerOnChange, assignees, document, scripts, error } = useDocument(
 )
 
 const doc = computed(() => document.doc || {})
+
+// Permission to delete the current lead
+const canDeleteLead = createResource({
+  url: 'crm.api.lead.can_delete_lead',
+  params: { name: props.leadId },
+  cache: ['can_delete_lead', props.leadId],
+  auto: true,
+})
 
 watch(error, (err) => {
   if (err) {
@@ -502,14 +511,6 @@ function openSmsBox() {
       activities.value.emailBox.showComment = false
     activities.value?.smsBox?.show?.()
   })
-}
-
-function openSmsBox() {
-  let currentTab = tabs.value[tabIndex.value]
-  if (!['SMS', 'Activity'].includes(currentTab.name)) {
-    activities.value.changeTabTo('sms')
-  }
-  nextTick(() => activities.value?.smsBox?.show?.())
 }
 
 function saveChanges(data) {

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -126,6 +126,16 @@
                 />
 
                 <Button
+                  :tooltip="__('Send SMS')"
+                  :icon="SmsIcon"
+                  @click="
+                    doc.mobile_no
+                      ? openSmsBox()
+                      : toast.error(__('No phone number set'))
+                  "
+                />
+
+                <Button
                   :tooltip="__('Send an email')"
                   :icon="Email2Icon"
                   @click="
@@ -476,6 +486,14 @@ function openEmailBox() {
     activities.value.changeTabTo('emails')
   }
   nextTick(() => (activities.value.emailBox.show = true))
+}
+
+function openSmsBox() {
+  let currentTab = tabs.value[tabIndex.value]
+  if (!['SMS', 'Activity'].includes(currentTab.name)) {
+    activities.value.changeTabTo('sms')
+  }
+  nextTick(() => activities.value?.smsBox?.show?.())
 }
 
 function saveChanges(data) {

--- a/frontend/src/pages/SmsLogs.vue
+++ b/frontend/src/pages/SmsLogs.vue
@@ -87,49 +87,6 @@ const defaultFilters = {
   communication_medium: 'SMS',
 }
 
-// After first load, if default columns/rows are not ideal, set reasonable defaults
-watch(
-  () => smsLogs.value?.data?.columns,
-  (cols) => {
-    if (!smsLogs.value?.data || cols === undefined || cols === null) return
-    const isEmpty = Array.isArray(cols) && cols.length === 0
-    const isFallback = Array.isArray(cols)
-      && cols.length <= 2
-      && cols.map((c) => c.key).includes('name')
-      && cols.map((c) => c.key).includes('modified')
-
-  if (isEmpty || isFallback) {
-      smsLogs.value.params.columns = [
-        { label: 'Sender', type: 'Data', key: 'sender', width: '12rem' },
-        { label: 'Receiver', type: 'Data', key: 'receiver', width: '12rem' },
-        { label: 'From', type: 'Data', key: 'phone_no', width: '12rem' },
-        { label: 'To', type: 'Data', key: 'recipients', width: '12rem' },
-        { label: 'Message', type: 'Text', key: 'content', width: '1fr' },
-        { label: 'Direction', type: 'Data', key: 'sent_or_received', width: '8rem' },
-        { label: 'When', type: 'Datetime', key: 'creation', width: '10rem' },
-      ]
-      smsLogs.value.params.rows = [
-    'name',
-        'creation',
-        'sent_or_received',
-    'sender',
-    'receiver',
-        'phone_no',
-        'recipients',
-        'content',
-        'reference_doctype',
-        'reference_name',
-        '_liked_by',
-      ]
-      // Optionally increase page size for better first paint
-      smsLogs.value.params.page_length = smsLogs.value.params.page_length || 50
-      smsLogs.value.params.page_length_count = smsLogs.value.params.page_length_count || 50
-      smsLogs.value.reload()
-    }
-  },
-  { immediate: false },
-)
-
 const rows = computed(() => {
   if (
     !smsLogs.value?.data?.data ||
@@ -193,40 +150,6 @@ function openFromURL() {
 }
 
 onMounted(() => {
-  // Ensure first load has proper columns/rows so server returns records
-  const primeColumns = () => {
-    const p = smsLogs.value?.params
-    if (!p) return setTimeout(primeColumns, 10)
-    const noCols = !Array.isArray(p.columns) || p.columns.length === 0
-  if (noCols) {
-      p.columns = [
-        { label: 'Sender', type: 'Data', key: 'sender', width: '12rem' },
-        { label: 'Receiver', type: 'Data', key: 'receiver', width: '12rem' },
-        { label: 'From', type: 'Data', key: 'phone_no', width: '12rem' },
-        { label: 'To', type: 'Data', key: 'recipients', width: '12rem' },
-        { label: 'Message', type: 'Text', key: 'content', width: '1fr' },
-        { label: 'Direction', type: 'Data', key: 'sent_or_received', width: '8rem' },
-        { label: 'When', type: 'Datetime', key: 'creation', width: '10rem' },
-      ]
-      p.rows = [
-        'name',
-        'creation',
-        'sent_or_received',
-    'sender',
-    'receiver',
-        'phone_no',
-        'recipients',
-        'content',
-        'reference_doctype',
-        'reference_name',
-        '_liked_by',
-      ]
-      p.page_length = p.page_length || 50
-      p.page_length_count = p.page_length_count || 50
-      smsLogs.value.reload()
-    }
-  }
-  primeColumns()
   openFromURL()
 })
 


### PR DESCRIPTION
This pull request introduces a backend override for the `Communication` doctype to provide custom default columns and rows for SMS log listings, and removes redundant frontend logic that previously enforced these defaults. Now, the frontend relies on the backend to supply the correct structure, simplifying the Vue component and centralizing configuration.

Backend enhancements:

* Added a `CustomCommunication` class in `crm/overrides/communication.py` that overrides the default columns and rows for the `Communication` doctype, ensuring consistent structure for SMS logs.
* Registered the new `CustomCommunication` override in the `override_doctype_class` mapping in `crm/hooks.py`.

Frontend simplification:

* Removed the Vue `watch` and `onMounted` logic in `frontend/src/pages/SmsLogs.vue` that previously set default columns and rows for SMS logs, as this is now handled by the backend. [[1]](diffhunk://#diff-54375c8c65a363bdeff921d5a03adb4f15f07020d091a7d2a064320f8cdb5f58L90-L132) [[2]](diffhunk://#diff-54375c8c65a363bdeff921d5a03adb4f15f07020d091a7d2a064320f8cdb5f58L196-L229)